### PR TITLE
Minor calculation fix

### DIFF
--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -1241,7 +1241,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
     public void balanceEcoAndInd(float targetPopPercent) {
         targetPopPercent = Math.min(Math.max(targetPopPercent, 0), 1);
         // new pop next turn before spending
-        float baseNewPop = workingPopulation() + normalPopGrowth() + incomingTransportsNextTurn();
+        float baseNewPop = Math.min(planet.currentSize(), workingPopulation() + normalPopGrowth() + incomingTransportsNextTurn());
         // transports coming after next turn; use to limit pop growth spending
         float additionalTransports = Math.max(incomingTransports() - incomingTransportsNextTurn(), 0);
         // population target for growth spending


### PR DESCRIPTION
If incoming transports next turn were too many to fit on the planet, the allocation logic would still try to work off the total (too large) size.  I fixed it to cap population for calculations at the planet's current maximum size.